### PR TITLE
feat: 新增作业定位与批量处理工具，过滤字幕噪声

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ build/
 dist/
 *.spec
 whisper_models/
-homework_results/
+homework_results*/
 release_*/
 *.json
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 dist/
 *.spec
 whisper_models/
+homework_results/
 release_*/
 *.json
 .idea

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ _tips: 语音转文字所需的时间较长，可以先观看视频，字幕生�
 uv run python find_homework.py output
 ```
 
-默认只搜索关键词 `作业`，结果会保存到 `homework_results/homework_hits.csv`，截图会保存到 `homework_results/screenshots/`。
+默认只搜索关键词 `作业`，并把同一视频内相隔不超过 60 秒的命中合并为一个作业事件。结果会保存到 `homework_results/homework_hits.csv`，截图会保存到 `homework_results/screenshots/`。
 
 如需扩展关键词，可以多次传入 `-k`，或使用关键词文件：
 
@@ -139,6 +139,13 @@ uv run python find_homework.py output --keywords-file homework_keywords.txt
 
 ```bash
 uv run python find_homework.py output --no-screenshots
+```
+
+如需调整 CSV 和截图的时间窗口去重范围：
+
+```bash
+uv run python find_homework.py output --merge-gap 120
+uv run python find_homework.py output --merge-gap 0
 ```
 
 ## 依赖

--- a/README.md
+++ b/README.md
@@ -118,6 +118,29 @@ uv run python gui.py
 
 _tips: 语音转文字所需的时间较长，可以先观看视频，字幕生成好了再重新打开视频享受字幕。使用 GPU 大约需要几分钟，不使用 GPU 则需要更长时间。_
 
+## 从字幕中定位作业
+
+生成 `.srt` 字幕后，可以用 `find_homework.py` 搜索“作业”相关字幕时间点，并从同名屏幕录像中截取对应画面：
+
+```bash
+uv run python find_homework.py output
+```
+
+默认只搜索关键词 `作业`，结果会保存到 `homework_results/homework_hits.csv`，截图会保存到 `homework_results/screenshots/`。
+
+如需扩展关键词，可以多次传入 `-k`，或使用关键词文件：
+
+```bash
+uv run python find_homework.py output -k 作业 -k 提交 -k 截止
+uv run python find_homework.py output --keywords-file homework_keywords.txt
+```
+
+如果只想生成时间点报告、不截图：
+
+```bash
+uv run python find_homework.py output --no-screenshots
+```
+
 ## 依赖
 
 - ffmpeg，已在 Release 中提供。若在 Linux 环境下运行，需手动安装 ffmpeg：

--- a/README.md
+++ b/README.md
@@ -156,9 +156,16 @@ uv run python batch_homework.py output
 
 脚本会扫描 `output/` 下的 `.mp4` 文件，优先使用同名 `.aac` 生成字幕，已有 `.srt` 会自动跳过。每节课的报告会分别保存到 `homework_results/视频名/homework_hits.csv`，截图保存到对应目录的 `screenshots/` 中。
 
+如果只想处理某一门课程，传入该课程的子目录即可：
+
+```bash
+uv run python batch_homework.py "output/专利信息与科技创新-screen"
+```
+
 常用参数示例：
 
 ```bash
+uv run python batch_homework.py output --output homework_results_batch
 uv run python batch_homework.py output --no-screenshots
 uv run python batch_homework.py output --device cuda --model large-v3-turbo
 uv run python batch_homework.py output --overwrite-srt

--- a/README.md
+++ b/README.md
@@ -162,8 +162,11 @@ uv run python batch_homework.py output
 uv run python batch_homework.py output --no-screenshots
 uv run python batch_homework.py output --device cuda --model large-v3-turbo
 uv run python batch_homework.py output --overwrite-srt
+uv run python batch_homework.py output --whisper-progress
 uv run python batch_homework.py output -k 作业 -k 提交 -k 截止
 ```
+
+默认只显示批处理级别日志；如果需要查看 Whisper 转写时的内部进度条，可以加 `--whisper-progress`。
 
 ## 依赖
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,23 @@ uv run python find_homework.py output --merge-gap 120
 uv run python find_homework.py output --merge-gap 0
 ```
 
+如果要对已下载的一批屏幕视频批量生成字幕并逐节课搜索作业，可以运行：
+
+```bash
+uv run python batch_homework.py output
+```
+
+脚本会扫描 `output/` 下的 `.mp4` 文件，优先使用同名 `.aac` 生成字幕，已有 `.srt` 会自动跳过。每节课的报告会分别保存到 `homework_results/视频名/homework_hits.csv`，截图保存到对应目录的 `screenshots/` 中。
+
+常用参数示例：
+
+```bash
+uv run python batch_homework.py output --no-screenshots
+uv run python batch_homework.py output --device cuda --model large-v3-turbo
+uv run python batch_homework.py output --overwrite-srt
+uv run python batch_homework.py output -k 作业 -k 提交 -k 截止
+```
+
 ## 依赖
 
 - ffmpeg，已在 Release 中提供。若在 Linux 环境下运行，需手动安装 ffmpeg：

--- a/batch_homework.py
+++ b/batch_homework.py
@@ -1,0 +1,221 @@
+import argparse
+import subprocess
+import time
+from pathlib import Path
+
+import torch
+import whisper
+from zhconv import convert
+
+import find_homework
+from gen_caption import DEFAULT_CLI_MODEL, seconds_to_hmsm
+
+
+MEDIA_EXTENSIONS = (".mp4",)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Generate captions for downloaded video/audio pairs, then search homework hits per lesson."
+    )
+    parser.add_argument(
+        "root",
+        nargs="?",
+        default="output",
+        help="Directory to scan for downloaded .mp4 files. Defaults to output/.",
+    )
+    parser.add_argument(
+        "--output",
+        default="homework_results",
+        help="Parent directory for per-lesson homework reports.",
+    )
+    parser.add_argument(
+        "--model",
+        default=DEFAULT_CLI_MODEL,
+        help=f"Whisper model name. Defaults to {DEFAULT_CLI_MODEL}.",
+    )
+    parser.add_argument(
+        "--device",
+        choices=("auto", "cuda", "cpu"),
+        default="auto",
+        help="Whisper device. Defaults to auto.",
+    )
+    parser.add_argument(
+        "--overwrite-srt",
+        action="store_true",
+        help="Regenerate captions even when the .srt file already exists.",
+    )
+    parser.add_argument(
+        "-k",
+        "--keyword",
+        action="append",
+        dest="keywords",
+        help="Homework keyword. Can be used multiple times. Defaults to 作业.",
+    )
+    parser.add_argument(
+        "--keywords-file",
+        help="Text file with one keyword per line. Blank lines and lines starting with # are ignored.",
+    )
+    parser.add_argument(
+        "--screenshot-offsets",
+        default="0",
+        help="Comma-separated seconds relative to each matched event start, e.g. -10,0,10.",
+    )
+    parser.add_argument(
+        "--merge-gap",
+        type=float,
+        default=find_homework.DEFAULT_MERGE_GAP,
+        help="Merge hits in the same video when the next hit starts within this many seconds. Defaults to 60.",
+    )
+    parser.add_argument(
+        "--no-screenshots",
+        action="store_true",
+        help="Only write CSV reports; do not call ffmpeg for screenshots.",
+    )
+    parser.add_argument(
+        "--case-sensitive",
+        action="store_true",
+        help="Use case-sensitive matching for ASCII keywords.",
+    )
+    return parser.parse_args()
+
+
+def select_device(device_arg: str) -> str:
+    if device_arg == "auto":
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    if device_arg == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("CUDA was requested, but torch.cuda.is_available() is false.")
+    return device_arg
+
+
+def find_video_files(root: Path) -> list[Path]:
+    if root.is_file():
+        if root.suffix.lower() not in MEDIA_EXTENSIONS:
+            raise ValueError(f"Expected a .mp4 file or directory: {root}")
+        return [root]
+    return sorted(path for path in root.rglob("*.mp4") if path.is_file())
+
+
+def media_for_video(video_path: Path) -> Path:
+    audio_path = video_path.with_suffix(".aac")
+    return audio_path if audio_path.exists() else video_path
+
+
+def extract_audio(video_path: Path) -> Path:
+    audio_path = video_path.with_suffix(".m4a")
+    command = [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-i",
+        str(video_path),
+        "-vn",
+        "-ar",
+        str(whisper.audio.SAMPLE_RATE),
+        "-y",
+        str(audio_path),
+    ]
+    subprocess.run(command, check=True)
+    return audio_path
+
+
+def write_srt(segments: list[dict], srt_path: Path) -> None:
+    with srt_path.open("w", encoding="utf-8") as f:
+        for index, segment in enumerate(segments, 1):
+            f.write(f"{index}\n")
+            f.write(
+                seconds_to_hmsm(float(segment["start"]))
+                + " --> "
+                + seconds_to_hmsm(float(segment["end"]))
+                + "\n"
+            )
+            f.write(convert(segment["text"], "zh-cn") + "\n\n")
+
+
+def generate_caption(model, media_path: Path, srt_path: Path, device: str) -> None:
+    audio_path = media_path
+    remove_audio = False
+    if media_path.suffix.lower() == ".mp4":
+        audio_path = extract_audio(media_path)
+        remove_audio = True
+
+    try:
+        start = time.time()
+        result = model.transcribe(
+            str(audio_path),
+            verbose=False,
+            language="zh",
+            fp16=(device == "cuda"),
+        )
+        write_srt(result["segments"], srt_path)
+        print(f"[caption done] {srt_path} ({time.time() - start:.1f}s)")
+    finally:
+        if remove_audio and audio_path.exists():
+            audio_path.unlink()
+
+
+def write_homework_report(
+    srt_path: Path,
+    output_dir: Path,
+    keywords: list[str],
+    offsets: list[float],
+    merge_gap: float,
+    no_screenshots: bool,
+    case_sensitive: bool,
+) -> tuple[int, int, Path]:
+    hits = find_homework.collect_hits([srt_path], keywords, case_sensitive)
+    events = find_homework.merge_hits(hits, merge_gap)
+    if not no_screenshots:
+        find_homework.add_screenshots(events, output_dir, offsets)
+    csv_path = find_homework.write_csv(events, output_dir)
+    return len(hits), len(events), csv_path
+
+
+def main():
+    args = parse_args()
+    root = Path(args.root)
+    output_root = Path(args.output)
+    videos = find_video_files(root)
+    if not videos:
+        print(f"No .mp4 files found under {root}")
+        return
+
+    device = select_device(args.device)
+    keywords = find_homework.load_keywords(args)
+    offsets = find_homework.parse_offsets(args.screenshot_offsets)
+
+    print(f"Found {len(videos)} video file(s).")
+    print(f"Using Whisper model: {args.model}")
+    print(f"Using device: {device}")
+    if device == "cuda":
+        print(f"CUDA device: {torch.cuda.get_device_name(0)}")
+
+    model = whisper.load_model(args.model, device=device, download_root="whisper_models/")
+
+    for index, video_path in enumerate(videos, 1):
+        media_path = media_for_video(video_path)
+        srt_path = video_path.with_suffix(".srt")
+        lesson_output = output_root / find_homework.safe_stem(video_path)
+
+        print(f"[{index}/{len(videos)}] {video_path}")
+        print(f"[media] {media_path}")
+        if args.overwrite_srt or not srt_path.exists():
+            generate_caption(model, media_path, srt_path, device)
+        else:
+            print(f"[caption skip] {srt_path}")
+
+        hit_count, event_count, csv_path = write_homework_report(
+            srt_path=srt_path,
+            output_dir=lesson_output,
+            keywords=keywords,
+            offsets=offsets,
+            merge_gap=args.merge_gap,
+            no_screenshots=args.no_screenshots,
+            case_sensitive=args.case_sensitive,
+        )
+        print(f"[homework done] {hit_count} hit(s), {event_count} event(s): {csv_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/batch_homework.py
+++ b/batch_homework.py
@@ -8,7 +8,7 @@ import whisper
 from zhconv import convert
 
 import find_homework
-from gen_caption import DEFAULT_CLI_MODEL, seconds_to_hmsm
+from gen_caption import DEFAULT_CLI_MODEL, NOISE_PHRASES, seconds_to_hmsm
 
 
 MEDIA_EXTENSIONS = (".mp4",)
@@ -129,17 +129,30 @@ def extract_audio(video_path: Path) -> Path:
     return audio_path
 
 
+def contains_noise(text: str) -> bool:
+    """Return True if text contains any known noise phrase from whisper contamination."""
+    for phrase in NOISE_PHRASES:
+        if phrase in text:
+            return True
+    return False
+
+
 def write_srt(segments: list[dict], srt_path: Path) -> None:
     with srt_path.open("w", encoding="utf-8") as f:
-        for index, segment in enumerate(segments, 1):
-            f.write(f"{index}\n")
+        srt_index = 0
+        for segment in segments:
+            text = convert(segment["text"], "zh-cn")
+            if contains_noise(text):
+                continue
+            srt_index += 1
+            f.write(f"{srt_index}\n")
             f.write(
                 seconds_to_hmsm(float(segment["start"]))
                 + " --> "
                 + seconds_to_hmsm(float(segment["end"]))
                 + "\n"
             )
-            f.write(convert(segment["text"], "zh-cn") + "\n\n")
+            f.write(text + "\n\n")
 
 
 def generate_caption(

--- a/batch_homework.py
+++ b/batch_homework.py
@@ -14,6 +14,10 @@ from gen_caption import DEFAULT_CLI_MODEL, seconds_to_hmsm
 MEDIA_EXTENSIONS = (".mp4",)
 
 
+def log(message: str) -> None:
+    print(message, flush=True)
+
+
 def parse_args():
     parser = argparse.ArgumentParser(
         description="Generate captions for downloaded video/audio pairs, then search homework hits per lesson."
@@ -44,6 +48,11 @@ def parse_args():
         "--overwrite-srt",
         action="store_true",
         help="Regenerate captions even when the .srt file already exists.",
+    )
+    parser.add_argument(
+        "--whisper-progress",
+        action="store_true",
+        help="Show Whisper's internal tqdm progress while transcribing. Hidden by default.",
     )
     parser.add_argument(
         "-k",
@@ -133,7 +142,13 @@ def write_srt(segments: list[dict], srt_path: Path) -> None:
             f.write(convert(segment["text"], "zh-cn") + "\n\n")
 
 
-def generate_caption(model, media_path: Path, srt_path: Path, device: str) -> None:
+def generate_caption(
+    model,
+    media_path: Path,
+    srt_path: Path,
+    device: str,
+    whisper_progress: bool,
+) -> None:
     audio_path = media_path
     remove_audio = False
     if media_path.suffix.lower() == ".mp4":
@@ -144,12 +159,12 @@ def generate_caption(model, media_path: Path, srt_path: Path, device: str) -> No
         start = time.time()
         result = model.transcribe(
             str(audio_path),
-            verbose=False,
+            verbose=False if whisper_progress else None,
             language="zh",
             fp16=(device == "cuda"),
         )
         write_srt(result["segments"], srt_path)
-        print(f"[caption done] {srt_path} ({time.time() - start:.1f}s)")
+        log(f"[caption done] {srt_path} ({time.time() - start:.1f}s)")
     finally:
         if remove_audio and audio_path.exists():
             audio_path.unlink()
@@ -173,37 +188,62 @@ def write_homework_report(
 
 
 def main():
+    start_time = time.time()
     args = parse_args()
     root = Path(args.root)
     output_root = Path(args.output)
     videos = find_video_files(root)
     if not videos:
-        print(f"No .mp4 files found under {root}")
+        log(f"No .mp4 files found under {root}")
         return
 
     device = select_device(args.device)
     keywords = find_homework.load_keywords(args)
     offsets = find_homework.parse_offsets(args.screenshot_offsets)
 
-    print(f"Found {len(videos)} video file(s).")
-    print(f"Using Whisper model: {args.model}")
-    print(f"Using device: {device}")
+    log(f"Found {len(videos)} video file(s).")
+    log(f"Using Whisper model: {args.model}")
+    log(f"Using device: {device}")
     if device == "cuda":
-        print(f"CUDA device: {torch.cuda.get_device_name(0)}")
+        log(f"CUDA device: {torch.cuda.get_device_name(0)}")
 
-    model = whisper.load_model(args.model, device=device, download_root="whisper_models/")
+    captions_to_generate = [
+        video_path
+        for video_path in videos
+        if args.overwrite_srt or not video_path.with_suffix(".srt").exists()
+    ]
+    log(f"Captions to generate: {len(captions_to_generate)}")
+
+    model = None
+    if captions_to_generate:
+        model = whisper.load_model(args.model, device=device, download_root="whisper_models/")
+
+    generated_captions = 0
+    skipped_captions = 0
+    total_hits = 0
+    total_events = 0
 
     for index, video_path in enumerate(videos, 1):
         media_path = media_for_video(video_path)
         srt_path = video_path.with_suffix(".srt")
         lesson_output = output_root / find_homework.safe_stem(video_path)
 
-        print(f"[{index}/{len(videos)}] {video_path}")
-        print(f"[media] {media_path}")
+        log(f"[{index}/{len(videos)}] {video_path}")
+        log(f"[media] {media_path}")
         if args.overwrite_srt or not srt_path.exists():
-            generate_caption(model, media_path, srt_path, device)
+            if model is None:
+                raise RuntimeError("Internal error: caption generation requires a loaded Whisper model.")
+            generate_caption(
+                model,
+                media_path,
+                srt_path,
+                device,
+                args.whisper_progress,
+            )
+            generated_captions += 1
         else:
-            print(f"[caption skip] {srt_path}")
+            log(f"[caption skip] {srt_path}")
+            skipped_captions += 1
 
         hit_count, event_count, csv_path = write_homework_report(
             srt_path=srt_path,
@@ -214,7 +254,18 @@ def main():
             no_screenshots=args.no_screenshots,
             case_sensitive=args.case_sensitive,
         )
-        print(f"[homework done] {hit_count} hit(s), {event_count} event(s): {csv_path}")
+        total_hits += hit_count
+        total_events += event_count
+        log(f"[homework done] {hit_count} hit(s), {event_count} event(s): {csv_path}")
+
+    log("[summary]")
+    log(f"Videos processed: {len(videos)}")
+    log(f"Captions generated: {generated_captions}")
+    log(f"Captions skipped: {skipped_captions}")
+    log(f"Homework hits: {total_hits}")
+    log(f"Homework events: {total_events}")
+    log(f"Output directory: {output_root}")
+    log(f"Elapsed: {time.time() - start_time:.1f}s")
 
 
 if __name__ == "__main__":

--- a/find_homework.py
+++ b/find_homework.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 DEFAULT_KEYWORDS = ["作业"]
 DEFAULT_SCREENSHOT_OFFSETS = [0.0]
+DEFAULT_MERGE_GAP = 60.0
 MEDIA_EXTENSIONS = (".mp4", ".mkv", ".mov", ".avi")
 
 
@@ -25,7 +26,37 @@ class HomeworkHit:
     srt_path: Path
     segment: SubtitleSegment
     keywords: list[str]
+
+
+@dataclass
+class HomeworkEvent:
+    video_path: Path | None
+    srt_path: Path
+    hits: list[HomeworkHit]
     screenshots: list[Path]
+
+    @property
+    def start(self) -> float:
+        return self.hits[0].segment.start
+
+    @property
+    def end(self) -> float:
+        return max(hit.segment.end for hit in self.hits)
+
+    @property
+    def keywords(self) -> list[str]:
+        seen = set()
+        keywords = []
+        for hit in self.hits:
+            for keyword in hit.keywords:
+                if keyword not in seen:
+                    seen.add(keyword)
+                    keywords.append(keyword)
+        return keywords
+
+    @property
+    def text(self) -> str:
+        return " ".join(hit.segment.text for hit in self.hits)
 
 
 def parse_args():
@@ -57,7 +88,13 @@ def parse_args():
     parser.add_argument(
         "--screenshot-offsets",
         default="0",
-        help="Comma-separated seconds relative to each matched subtitle start, e.g. -10,0,10.",
+        help="Comma-separated seconds relative to each matched event start, e.g. -10,0,10.",
+    )
+    parser.add_argument(
+        "--merge-gap",
+        type=float,
+        default=DEFAULT_MERGE_GAP,
+        help="Merge hits in the same video when the next hit starts within this many seconds. Defaults to 60. Use 0 to disable.",
     )
     parser.add_argument(
         "--no-screenshots",
@@ -224,29 +261,57 @@ def collect_hits(
                         srt_path=srt_path,
                         segment=segment,
                         keywords=matched,
-                        screenshots=[],
                     )
                 )
     return hits
 
 
-def add_screenshots(hits: list[HomeworkHit], output_dir: Path, offsets: list[float]) -> None:
+def merge_hits(hits: list[HomeworkHit], merge_gap: float) -> list[HomeworkEvent]:
+    events = []
+    current_event = None
+    sorted_hits = sorted(
+        hits,
+        key=lambda hit: (str(hit.srt_path), hit.segment.start, hit.segment.index),
+    )
+
+    for hit in sorted_hits:
+        if (
+            current_event is None
+            or current_event.srt_path != hit.srt_path
+            or hit.segment.start - current_event.end > merge_gap
+        ):
+            current_event = HomeworkEvent(
+                video_path=hit.video_path,
+                srt_path=hit.srt_path,
+                hits=[hit],
+                screenshots=[],
+            )
+            events.append(current_event)
+        else:
+            current_event.hits.append(hit)
+
+    return events
+
+
+def add_screenshots(
+    events: list[HomeworkEvent], output_dir: Path, offsets: list[float]
+) -> None:
     screenshot_dir = output_dir / "screenshots"
-    for hit in hits:
-        if not hit.video_path:
+    for event_index, event in enumerate(events, 1):
+        if not event.video_path:
             continue
-        video_stem = safe_stem(hit.video_path)
+        video_stem = safe_stem(event.video_path)
         for offset in offsets:
-            timestamp = max(0.0, hit.segment.start + offset)
+            timestamp = max(0.0, event.start + offset)
             screenshot_name = (
-                f"{video_stem}_sub{hit.segment.index:04d}_{timestamp_for_filename(timestamp)}.jpg"
+                f"{video_stem}_event{event_index:04d}_{timestamp_for_filename(timestamp)}.jpg"
             )
             screenshot_path = screenshot_dir / screenshot_name
-            if capture_screenshot(hit.video_path, timestamp, screenshot_path):
-                hit.screenshots.append(screenshot_path)
+            if capture_screenshot(event.video_path, timestamp, screenshot_path):
+                event.screenshots.append(screenshot_path)
 
 
-def write_csv(hits: list[HomeworkHit], output_dir: Path) -> Path:
+def write_csv(events: list[HomeworkEvent], output_dir: Path) -> Path:
     output_dir.mkdir(parents=True, exist_ok=True)
     csv_path = output_dir / "homework_hits.csv"
     with csv_path.open("w", encoding="utf-8-sig", newline="") as f:
@@ -255,25 +320,27 @@ def write_csv(hits: list[HomeworkHit], output_dir: Path) -> Path:
             [
                 "srt",
                 "video",
-                "subtitle_index",
                 "start",
                 "end",
+                "hit_count",
+                "subtitle_indexes",
                 "keywords",
                 "text",
                 "screenshots",
             ]
         )
-        for hit in hits:
+        for event in events:
             writer.writerow(
                 [
-                    str(hit.srt_path),
-                    str(hit.video_path or ""),
-                    hit.segment.index,
-                    format_timestamp(hit.segment.start),
-                    format_timestamp(hit.segment.end),
-                    "|".join(hit.keywords),
-                    hit.segment.text,
-                    "|".join(str(path) for path in hit.screenshots),
+                    str(event.srt_path),
+                    str(event.video_path or ""),
+                    format_timestamp(event.start),
+                    format_timestamp(event.end),
+                    len(event.hits),
+                    "|".join(str(hit.segment.index) for hit in event.hits),
+                    "|".join(event.keywords),
+                    event.text,
+                    "|".join(str(path) for path in event.screenshots),
                 ]
             )
     return csv_path
@@ -292,12 +359,13 @@ def main():
         return
 
     hits = collect_hits(srt_files, keywords, args.case_sensitive)
+    events = merge_hits(hits, args.merge_gap)
     if not args.no_screenshots:
-        add_screenshots(hits, output_dir, offsets)
+        add_screenshots(events, output_dir, offsets)
 
-    csv_path = write_csv(hits, output_dir)
+    csv_path = write_csv(events, output_dir)
     print(f"Scanned {len(srt_files)} subtitle file(s).")
-    print(f"Found {len(hits)} hit(s) for keywords: {', '.join(keywords)}")
+    print(f"Found {len(hits)} hit(s) in {len(events)} event(s) for keywords: {', '.join(keywords)}")
     print(f"Report: {csv_path}")
 
 

--- a/find_homework.py
+++ b/find_homework.py
@@ -1,0 +1,305 @@
+import argparse
+import csv
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DEFAULT_KEYWORDS = ["作业"]
+DEFAULT_SCREENSHOT_OFFSETS = [0.0]
+MEDIA_EXTENSIONS = (".mp4", ".mkv", ".mov", ".avi")
+
+
+@dataclass
+class SubtitleSegment:
+    index: int
+    start: float
+    end: float
+    text: str
+
+
+@dataclass
+class HomeworkHit:
+    video_path: Path | None
+    srt_path: Path
+    segment: SubtitleSegment
+    keywords: list[str]
+    screenshots: list[Path]
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Search generated SRT captions for homework keywords and capture nearby screenshots."
+    )
+    parser.add_argument(
+        "root",
+        nargs="?",
+        default="output",
+        help="Directory or .srt file to scan. Defaults to output/.",
+    )
+    parser.add_argument(
+        "-k",
+        "--keyword",
+        action="append",
+        dest="keywords",
+        help="Keyword to search. Can be used multiple times. Defaults to 作业.",
+    )
+    parser.add_argument(
+        "--keywords-file",
+        help="Text file with one keyword per line. Blank lines and lines starting with # are ignored.",
+    )
+    parser.add_argument(
+        "--output",
+        default="homework_results",
+        help="Directory for CSV report and screenshots.",
+    )
+    parser.add_argument(
+        "--screenshot-offsets",
+        default="0",
+        help="Comma-separated seconds relative to each matched subtitle start, e.g. -10,0,10.",
+    )
+    parser.add_argument(
+        "--no-screenshots",
+        action="store_true",
+        help="Only write the CSV report; do not call ffmpeg for screenshots.",
+    )
+    parser.add_argument(
+        "--case-sensitive",
+        action="store_true",
+        help="Use case-sensitive matching for ASCII keywords.",
+    )
+    return parser.parse_args()
+
+
+def load_keywords(args) -> list[str]:
+    keywords = list(args.keywords or DEFAULT_KEYWORDS)
+    if args.keywords_file:
+        keyword_path = Path(args.keywords_file)
+        for line in keyword_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                keywords.append(line)
+
+    seen = set()
+    deduped = []
+    for keyword in keywords:
+        keyword = keyword.strip()
+        if keyword and keyword not in seen:
+            seen.add(keyword)
+            deduped.append(keyword)
+    return deduped
+
+
+def parse_offsets(raw_offsets: str) -> list[float]:
+    offsets = []
+    for item in raw_offsets.split(","):
+        item = item.strip()
+        if item:
+            offsets.append(float(item))
+    return offsets or DEFAULT_SCREENSHOT_OFFSETS
+
+
+def parse_srt_time(value: str) -> float:
+    match = re.fullmatch(r"(\d{2}):(\d{2}):(\d{2}),(\d{3})", value.strip())
+    if not match:
+        raise ValueError(f"Invalid SRT timestamp: {value}")
+    hours, minutes, seconds, milliseconds = [int(part) for part in match.groups()]
+    return hours * 3600 + minutes * 60 + seconds + milliseconds / 1000
+
+
+def format_timestamp(seconds: float) -> str:
+    seconds = max(0.0, seconds)
+    hours = int(seconds // 3600)
+    minutes = int((seconds % 3600) // 60)
+    secs = int(seconds % 60)
+    milliseconds = int(round((seconds - int(seconds)) * 1000))
+    if milliseconds == 1000:
+        secs += 1
+        milliseconds = 0
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}.{milliseconds:03d}"
+
+
+def timestamp_for_filename(seconds: float) -> str:
+    return format_timestamp(seconds).replace(":", "-").replace(".", "-")
+
+
+def parse_srt(path: Path) -> list[SubtitleSegment]:
+    content = path.read_text(encoding="utf-8-sig")
+    blocks = re.split(r"\n\s*\n", content.strip())
+    segments = []
+    for block in blocks:
+        lines = [line.strip() for line in block.splitlines() if line.strip()]
+        if len(lines) < 2:
+            continue
+
+        if "-->" in lines[0]:
+            index = len(segments) + 1
+            time_line = lines[0]
+            text_lines = lines[1:]
+        else:
+            try:
+                index = int(lines[0])
+            except ValueError:
+                index = len(segments) + 1
+            time_line = lines[1]
+            text_lines = lines[2:]
+
+        if "-->" not in time_line:
+            continue
+        start_raw, end_raw = [part.strip().split()[0] for part in time_line.split("-->", 1)]
+        segments.append(
+            SubtitleSegment(
+                index=index,
+                start=parse_srt_time(start_raw),
+                end=parse_srt_time(end_raw),
+                text=" ".join(text_lines),
+            )
+        )
+    return segments
+
+
+def find_srt_files(root: Path) -> list[Path]:
+    if root.is_file():
+        if root.suffix.lower() != ".srt":
+            raise ValueError(f"Expected a .srt file or directory: {root}")
+        return [root]
+    return sorted(root.rglob("*.srt"))
+
+
+def find_matching_video(srt_path: Path) -> Path | None:
+    base_path = srt_path.with_suffix("")
+    for extension in MEDIA_EXTENSIONS:
+        video_path = base_path.with_suffix(extension)
+        if video_path.exists():
+            return video_path
+    return None
+
+
+def match_keywords(text: str, keywords: list[str], case_sensitive: bool) -> list[str]:
+    if case_sensitive:
+        return [keyword for keyword in keywords if keyword in text]
+    lowered_text = text.lower()
+    return [keyword for keyword in keywords if keyword.lower() in lowered_text]
+
+
+def safe_stem(path: Path) -> str:
+    return re.sub(r'[\\/:*?"<>|\s]+', "_", path.stem).strip("_")
+
+
+def capture_screenshot(video_path: Path, timestamp: float, output_path: Path) -> bool:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    command = [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-ss",
+        format_timestamp(timestamp),
+        "-i",
+        str(video_path),
+        "-frames:v",
+        "1",
+        "-y",
+        str(output_path),
+    ]
+    result = subprocess.run(command)
+    return result.returncode == 0 and output_path.exists()
+
+
+def collect_hits(
+    srt_files: list[Path],
+    keywords: list[str],
+    case_sensitive: bool,
+) -> list[HomeworkHit]:
+    hits = []
+    for srt_path in srt_files:
+        video_path = find_matching_video(srt_path)
+        for segment in parse_srt(srt_path):
+            matched = match_keywords(segment.text, keywords, case_sensitive)
+            if matched:
+                hits.append(
+                    HomeworkHit(
+                        video_path=video_path,
+                        srt_path=srt_path,
+                        segment=segment,
+                        keywords=matched,
+                        screenshots=[],
+                    )
+                )
+    return hits
+
+
+def add_screenshots(hits: list[HomeworkHit], output_dir: Path, offsets: list[float]) -> None:
+    screenshot_dir = output_dir / "screenshots"
+    for hit in hits:
+        if not hit.video_path:
+            continue
+        video_stem = safe_stem(hit.video_path)
+        for offset in offsets:
+            timestamp = max(0.0, hit.segment.start + offset)
+            screenshot_name = (
+                f"{video_stem}_sub{hit.segment.index:04d}_{timestamp_for_filename(timestamp)}.jpg"
+            )
+            screenshot_path = screenshot_dir / screenshot_name
+            if capture_screenshot(hit.video_path, timestamp, screenshot_path):
+                hit.screenshots.append(screenshot_path)
+
+
+def write_csv(hits: list[HomeworkHit], output_dir: Path) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = output_dir / "homework_hits.csv"
+    with csv_path.open("w", encoding="utf-8-sig", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(
+            [
+                "srt",
+                "video",
+                "subtitle_index",
+                "start",
+                "end",
+                "keywords",
+                "text",
+                "screenshots",
+            ]
+        )
+        for hit in hits:
+            writer.writerow(
+                [
+                    str(hit.srt_path),
+                    str(hit.video_path or ""),
+                    hit.segment.index,
+                    format_timestamp(hit.segment.start),
+                    format_timestamp(hit.segment.end),
+                    "|".join(hit.keywords),
+                    hit.segment.text,
+                    "|".join(str(path) for path in hit.screenshots),
+                ]
+            )
+    return csv_path
+
+
+def main():
+    args = parse_args()
+    root = Path(args.root)
+    output_dir = Path(args.output)
+    keywords = load_keywords(args)
+    offsets = parse_offsets(args.screenshot_offsets)
+    srt_files = find_srt_files(root)
+
+    if not srt_files:
+        print(f"No .srt files found under {root}")
+        return
+
+    hits = collect_hits(srt_files, keywords, args.case_sensitive)
+    if not args.no_screenshots:
+        add_screenshots(hits, output_dir, offsets)
+
+    csv_path = write_csv(hits, output_dir)
+    print(f"Scanned {len(srt_files)} subtitle file(s).")
+    print(f"Found {len(hits)} hit(s) for keywords: {', '.join(keywords)}")
+    print(f"Report: {csv_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/gen_caption.py
+++ b/gen_caption.py
@@ -8,6 +8,12 @@ from zhconv import convert  # 简繁体转换
 
 DEFAULT_CLI_MODEL = "large-v3-turbo"
 
+# Known noise phrases hallucinated by whisper due to training data contamination.
+# Extend this list when new contamination patterns are discovered.
+NOISE_PHRASES = [
+    "明镜与点点",  # 匹配各种 whisper 变体：明镜与点点栏目/栗目/株目...
+]
+
 
 def seconds_to_hmsm(seconds):
     """
@@ -85,6 +91,10 @@ def main():
         with open(base_path + ".srt", "w", encoding="utf-8") as f:
             i = 1
             for r in result["segments"]:
+                # 过滤 whisper 数据污染产生的噪声短语
+                text = convert(r["text"], "zh-cn")
+                if any(phrase in text for phrase in NOISE_PHRASES):
+                    continue
                 f.write(str(i) + "\n")
                 f.write(
                     seconds_to_hmsm(float(r["start"]))
@@ -93,9 +103,7 @@ def main():
                     + "\n"
                 )
                 i += 1
-                f.write(
-                    convert(r["text"], "zh-cn") + "\n"
-                )  # 结果可能是繁体，转为简体zh-cn
+                f.write(text + "\n")
                 f.write("\n")
 
         # 删除音频文件

--- a/gen_caption.py
+++ b/gen_caption.py
@@ -6,6 +6,9 @@ import whisper
 from zhconv import convert  # 简繁体转换
 
 
+DEFAULT_CLI_MODEL = "large-v3-turbo"
+
+
 def seconds_to_hmsm(seconds):
     """
     输入一个秒数，输出为H:M:S:M时间格式
@@ -35,6 +38,8 @@ def main():
     media_extensions = (".mp4", ".aac")
     if len(sys.argv) >= 2:
         video_paths.append(sys.argv[1])
+        model_name = sys.argv[2] if len(sys.argv) >= 3 else DEFAULT_CLI_MODEL
+        print("selected model:", model_name)
     else:
         files = []
         for dirpath, dirnames, filenames in os.walk("."):

--- a/gen_caption.py
+++ b/gen_caption.py
@@ -6,7 +6,7 @@ import whisper
 from zhconv import convert  # 简繁体转换
 
 
-DEFAULT_CLI_MODEL = "large-v3-turbo"
+DEFAULT_CLI_MODEL = "base"
 
 # Known noise phrases hallucinated by whisper due to training data contamination.
 # Extend this list when new contamination patterns are discovered.
@@ -67,11 +67,11 @@ def main():
                 continue
             print(f"[{len(models)}]: ", model)
             models.append(model)
-        model_index = input("select a model by input a num(default 'base'): ")
+        model_index = input(f"select a model by input a num(default '{DEFAULT_CLI_MODEL}'): ")
         try:
             model_name = models[eval(model_index)]
         except Exception:
-            model_name = "base"
+            model_name = DEFAULT_CLI_MODEL
         print("selected model:", model_name)
 
     for video_path in video_paths:

--- a/gen_caption.py
+++ b/gen_caption.py
@@ -11,7 +11,8 @@ DEFAULT_CLI_MODEL = "large-v3-turbo"
 # Known noise phrases hallucinated by whisper due to training data contamination.
 # Extend this list when new contamination patterns are discovered.
 NOISE_PHRASES = [
-    "明镜与点点",  # 匹配各种 whisper 变体：明镜与点点栏目/栗目/株目...
+    "明镜与点点",  # 匹配变体：明镜与点点栏目/栗目/株目...
+    "字幕志愿者",  # 匹配变体：字幕志愿者 李宗盛/杨茜茜...
 ]
 
 


### PR DESCRIPTION
## 变更内容

- 新增 `find_homework.py`，支持从 `.srt` 字幕中搜索“作业”等关键词，并输出命中时间点、截图和 CSV 报告
  - 支持按时间窗口合并相邻命中，减少重复截图和 CSV 记录
- 新增 `batch_homework.py`，可批量处理已下载的视频：
  - 优先复用同名音频文件生成字幕
  - 已存在字幕时默认跳过生成
  - 每个视频输出到独立结果目录
  - 支持 CUDA/CPU/auto 设备选择
- 默认隐藏 Whisper 内部进度条，批处理日志更简短；需要时可通过 `--whisper-progress` 开启
- README 增加作业搜索、批处理、课程子目录处理等 CLI 用法说明
- 修改 `gen_caption.py`：
  - 增加 whisper 字幕噪声过滤关键词列表
    - 目前有“明镜与点点”和“字幕志愿者”两项
    - 当一行字幕出现关键词，就跳过一整行
    - 在 `batch_homework.py` 中复用此列表
    - 这些意义不明又高频出现的字幕可能是模型数据污染导致的幻觉
  - 增加模型参数解析，以免非交互式 CLI 出错

## 使用示例

```bash
uv run python batch_homework.py output
uv run python batch_homework.py "output/<课程>-screen"
uv run python find_homework.py output --merge-gap 120
```

## 验证

- 已用当前下载的视频批量生成字幕并搜索作业
- 已验证已有字幕时不会重复加载 Whisper 模型
- 已验证批处理 summary 输出和实时日志输出正常
